### PR TITLE
test(Contracts): added test files for Ownable and Pausable contracts

### DIFF
--- a/test/Ownable.test.js
+++ b/test/Ownable.test.js
@@ -1,0 +1,47 @@
+const Ownable = artifacts.require("Ownable");
+
+require('chai').use(require('chai-as-promised')).should();
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
+// Owneable contract ...takes a list of accounts ( supply from truffle test env)
+contract('Ownable', async ([owner, other]) => {
+    // Reinitialize Ownable before each test
+    beforeEach(async function (){
+        // Call constructor from accounts[0]
+        this.ownable = await Ownable.new({from: owner});
+    });
+
+    // Test that owner was set on construction
+    describe('constructor()', function () {
+        it('should set msg.sender as the owner', async function () {
+            let checkedOwner = await this.ownable.owner();
+            assert.equal(checkedOwner, owner);
+        });
+    });
+
+    describe('transferOwnership()', function () {
+        it('should only be callable by owner', async function () {
+            // Other can't transfer ownership
+            await this.ownable.transferOwnership(other, {from: other}).should.be.rejected;
+            // Make sure owner is still owner
+            let checkedOwner = await this.ownable.owner();
+            assert.equal(checkedOwner, owner);
+        });
+
+        it('should not allow transfer to zero address', async function (){
+            await this.ownable.transferOwnership(ZERO_ADDRESS, {from: owner}).should.be.rejected;
+            // Make sure owner is still owner
+            let checkedOwner = await this.ownable.owner();
+            assert.equal(checkedOwner, owner);
+        });
+
+        it('should change owner after transfer', async function () {
+            // Other can't transfer ownership
+            await this.ownable.transferOwnership(other, {from: owner}).should.be.fulfilled;
+            // Make sure other is new owner
+            let checkedOwner = await this.ownable.owner();
+            assert.equal(checkedOwner, other);
+        });
+    });
+});

--- a/test/Pausable.test.js
+++ b/test/Pausable.test.js
@@ -1,0 +1,69 @@
+const Pausable = artifacts.require("Pausable");
+
+require('chai').use(require('chai-as-promised')).should();
+
+// Pausable contract ...takes a list of accounts ( supply from truffle test env)
+contract('Pausable', async ([owner, other]) => {
+    // Reinitialize Ownable before each test
+    beforeEach(async function (){
+        // Call constructor from accounts[0]
+        this.pausable = await Pausable.new({from: owner});
+    });
+
+    // Should start contract in unpaused state
+    describe('constructor()', function () {
+        it('should start unpaused', async function () {
+            let paused = await this.pausable.paused();
+            assert.isFalse(paused);
+        });
+    });
+
+    describe('pause()', function () {
+        it('should only be callable when not already paused', async function () {
+            // First call to pause should be fine
+            await this.pausable.pause().should.be.fulfilled;
+
+            // Second call rejected as it should be paused now
+            await this.pausable.pause().should.be.rejected;
+        });
+
+        it('should change state to paused', async function () {
+            await this.pausable.pause().should.be.fulfilled;
+            let paused = await this.pausable.paused();
+            assert.isTrue(paused);
+        });
+
+        it('should emit Pause event', async function () {
+            await this.pausable.pause();
+            
+            // TODO: 
+        });
+    });
+
+    describe('unpause()', function () {
+        // Start off paused for these tests
+        beforeEach(async function (){
+            await this.pausable.pause();
+        });
+
+        it('should only be callable when not already paused', async function () {
+            // First call to unpause should be fine
+            await this.pausable.unpause().should.be.fulfilled;
+
+            // Second call rejected as it should be unpaused now
+            await this.pausable.unpause().should.be.rejected;
+        });
+
+        it('should change state to unpaused', async function () {
+            await this.pausable.unpause().should.be.fulfilled;
+            let paused = await this.pausable.paused();
+            assert.isFalse(paused);
+        });
+
+        it('should emit Unpause event', async function () {
+            await this.pausable.unpause();
+            
+            // TODO: 
+        });
+    });
+});


### PR DESCRIPTION
### Description of the Change

Test files for Ownable and Pausable contract.
Tests all functions in these contracts.
100% test coverage for Ownable and Pausable.

Using chai-as-promised to check promises that should be rejected.  
