### PR TITLE
test(ERC223Token): added test for supporting ERC223 token transfer

### DIFF
--- a/contracts/mocks/TokenFallbackMock.sol
+++ b/contracts/mocks/TokenFallbackMock.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.23;
+
+/**
+ * @title Contract for testing the ERC223 token fallback
+ * @dev This just sets the values passed in on the contract state
+ * It would be nice to emit an event instead, but Truffle does not currently
+ * support checking internal events in tests: https://github.com/trufflesuite/truffle/issues/555
+ */
+contract TokenFallbackMock {
+    address public from;
+    uint public value;
+    bytes public data;
+
+    /**
+     * @dev Set state when fallback is called
+     * @param _from address The address that is transferring the tokens
+     * @param _value uint the amount of the specified token
+     * @param _data Bytes The data passed from the caller.
+     */
+    function tokenFallback(address _from, uint _value, bytes _data) external {
+        from = _from;
+        value = _value;
+        data = _data;
+    }
+}

--- a/test/ERC223Token.test.js
+++ b/test/ERC223Token.test.js
@@ -1,0 +1,39 @@
+const XchngToken = artifacts.require("XchngToken");
+const TokenFallbackMock = artifacts.require("TokenFallbackMock");
+
+// ERC223 contract token test
+contract('ERC223Token', async (accounts) => {
+    // 5Billion * 10^18 Xti tokens as initial supply
+    const PREALLOCATED_SUPPLY = 5000000000000000000000000000;
+    const ownerAddress = accounts[0];
+
+    // Create contract and token
+    beforeEach(async function (){
+        // Create the token with the preallocated supply and add all the tokens to ownerAddress
+        this.token = await XchngToken.new(ownerAddress, PREALLOCATED_SUPPLY);
+        this.tokenFallbackMock = await TokenFallbackMock.new();
+    });
+
+    describe('transfer()', function () {
+        // Transfer to the contract address will call the token fallback
+        it('should call token fallback and update mock state', async function () {
+            const amount = 10;
+            const to = this.tokenFallbackMock.address;
+
+            // Transfer without data
+            await this.token.transfer(to, 10);
+
+            // Check that the mock fallback contract's state was updated
+            let value = await this.tokenFallbackMock.value();
+            assert.equal(value, amount);
+
+            let from = await this.tokenFallbackMock.from();
+            assert.equal(ownerAddress, from);
+
+            // Transfer with data
+            // Note: Truffle test does not currently work with overloaded function names: 
+            // https://github.com/trufflesuite/truffle/issues/569
+            // this.token.transfer(this.tokenFallbackMock.address, 10, '');
+        });
+    });
+});


### PR DESCRIPTION
### Description of the Change

Added an ERC223Token test file to test transfers to a Contract address.  Uses a TokenFallbackMock contract that implements the tokenFallback function for testing.  When called this contract just sets the state using the parameters.

Unable to test the overloaded transfer function with data through Truffle currently due to open issue: https://github.com/trufflesuite/truffle/issues/569
