### PR TITLE
test(ERC223Token): added tests for transfer function with data

### DIFF
--- a/test/ERC223Token.test.js
+++ b/test/ERC223Token.test.js
@@ -17,7 +17,7 @@ contract('ERC223Token', async (accounts) => {
     describe('transfer()', function () {
         // Transfer to the contract address will call the token fallback
         it('should call token fallback and update mock state', async function () {
-            const amount = 10;
+            let amount = 10;
             const to = this.tokenFallbackMock.address;
 
             // Transfer without data
@@ -30,10 +30,15 @@ contract('ERC223Token', async (accounts) => {
             let from = await this.tokenFallbackMock.from();
             assert.equal(ownerAddress, from);
 
-            // Transfer with data
-            // Note: Truffle test does not currently work with overloaded function names: 
-            // https://github.com/trufflesuite/truffle/issues/569
-            // this.token.transfer(this.tokenFallbackMock.address, 10, '');
+            // Change amount for second test
+            amount = 100;
+
+            // Workaround for overloaded function until Truffle adds support.
+            // Must call contract with the function definition including parameters AND the from address included
+            this.token.contract.transfer['address,uint256,bytes'](to, amount, '', { from: ownerAddress });
+            // Check that the amount was updated
+            value = await this.tokenFallbackMock.value();
+            assert.equal(value, amount);
         });
     });
 });

--- a/test/XchngToken.test.js
+++ b/test/XchngToken.test.js
@@ -71,6 +71,35 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount]) => {
             assert.equal(logs[1].args._value, burnAmount.toNumber()); 
         });
     });
+
+    // --------------
+    //  ERC-223 tests 
+    // --------------
+    // Test ERC223 transfer with Data
+    // Note: This is using a workaround call to test the overloaded transfer function
+    // Cannot test reverts or check logs for events until Truffle fully supports overloaded functions.
+    describe('ERC223 transfer()', function() {
+        // valid address
+        describe('when the recipient is the not the zero address', function(){
+            const to = recipient;
+            const amount = 10;
+            // Assume that the owner has the PREALLOCATED_SUPPLY
+            describe('when the sender does have enough of a balance', function() {
+                const to = recipient;
+                const amount = 10; 
+                it('transfers the requested amount from the sender to the recipient', async function() {
+                    await this.token.contract.transfer['address,uint256,bytes'](to, amount, '', { from: ownerAddress });
+
+                    // check that the owner now has the updated balance 
+                    const ownerBalance = await this.token.balanceOf(ownerAddress);
+                    assert.equal(ownerBalance,(PREALLOCATED_SUPPLY-amount));
+                    // check that the recipient now has the amount transfered
+                    const recipientBalance = await this.token.balanceOf(to);
+                    assert.equal(recipientBalance, amount);
+                });
+            });
+        });
+    });
     
     // --------------
     //  ERC-20 tests 


### PR DESCRIPTION
### Description of the Change

Updated the ERC223Token test to use the workaround function call to test the overloaded transfer function that accepts bytes data as the third parameter.

See the trufflesuite issue for details on using the workaround"
https://github.com/trufflesuite/truffle/issues/820

Also updated the XchngToken test file to test that the transfer works correctly when to address is not a contract.   Due to having to call the function in the workaround way it is not possible to catch throws or parse a log return like the other transfer call so tests are not included for those cases.