### PR TITLE
fix(StandardToken): transferFrom uses correct from address in event

### DIFF
--- a/contracts/token/StandardToken.sol
+++ b/contracts/token/StandardToken.sol
@@ -144,7 +144,7 @@ contract StandardToken is ERC20Interface, ERC223Interface {
         balances[_from] = balances[_from].sub(_value);
         allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
 
-        emit Transfer(msg.sender, _to, _value);
+        emit Transfer(_from, _to, _value);
 
         return true;
     }

--- a/test/XchngToken.test.js
+++ b/test/XchngToken.test.js
@@ -278,17 +278,15 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
     describe('transferFrom()', function() {
         const spender = recipient;
         beforeEach(async function () {
-            // Give the approver a balance of 100
+            // Give the approver a balance of 100 and approve spender for 100 before each test
             await this.token.transfer(approver, 100, { from: ownerAddress });
+            await this.token.approve(spender, 100, { from: approver });
         });
 
         describe('when the recipient is not the zero address', function () {
             const to = anotherAccount;
 
             describe('when the spender has enough approved balance', function () {
-                beforeEach(async function () {
-                    await this.token.approve(spender, 100, { from: approver });
-                });
 
                 describe('when the approver has enough balance', function () {
                     const amount = 100;
@@ -338,14 +336,14 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
             });
 
             describe('when the spender does not have enough approved balance', function () {
-                beforeEach(async function () {
-                    await this.token.approve(spender, 99, { from: approver });
-                });
 
                 describe('when the approver has enough balance', function () {
                     const amount = 100;
 
                     it('reverts', async function () {
+                        // Override the spenders approved amount
+                        await this.token.approve(spender, 99, { from: approver });
+
                         await assertRevert(this.token.transferFrom(approver, to, amount, { from: spender }));
                     });
                 });
@@ -364,10 +362,6 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
             const amount = 100;
             const to = ZERO_ADDRESS;
 
-            beforeEach(async function () {
-                await this.token.approve(spender, amount, { from: approver });
-            });
-
             it('reverts', async function () {
                 await assertRevert(this.token.transferFrom(approver, to, amount, { from: spender }));
             });
@@ -375,10 +369,6 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
 
         describe('when the recipient is the Xchng contract address', function () {
             const amount = 100;
-
-            beforeEach(async function () {
-                await this.token.approve(spender, amount, { from: approver });
-            });
 
             it('reverts', async function () {
                 await assertRevert(this.token.transferFrom(approver, this.token.address, amount, { from: spender }));

--- a/test/XchngToken.test.js
+++ b/test/XchngToken.test.js
@@ -290,7 +290,7 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
                     await this.token.approve(spender, 100, { from: approver });
                 });
 
-                describe('when the owner has enough balance', function () {
+                describe('when the approver has enough balance', function () {
                     const amount = 100;
 
                     it('transfers the requested amount', async function () {
@@ -321,11 +321,18 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
                     });
                 });
 
-                describe('when the owner does not have enough balance', function () {
+                describe('when the approver does not have enough balance', function () {
                     const amount = 101;
 
                     it('reverts', async function () {
                         await assertRevert(this.token.transferFrom(approver, to, amount, { from: spender }));
+                    });
+                });
+
+                describe('when the approver is the zero address', function () {
+                    const amount = 100;
+                    it('reverts', async function () {
+                        await assertRevert(this.token.transferFrom(ZERO_ADDRESS, to, amount, { from: spender }));
                     });
                 });
             });
@@ -335,7 +342,7 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
                     await this.token.approve(spender, 99, { from: approver });
                 });
 
-                describe('when the owner has enough balance', function () {
+                describe('when the approver has enough balance', function () {
                     const amount = 100;
 
                     it('reverts', async function () {
@@ -343,7 +350,7 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
                     });
                 });
 
-                describe('when the owner does not have enough balance', function () {
+                describe('when the approver does not have enough balance', function () {
                     const amount = 101;
 
                     it('reverts', async function () {
@@ -363,6 +370,18 @@ contract('XchngToken', async ([ownerAddress,recipient,anotherAccount,approver]) 
 
             it('reverts', async function () {
                 await assertRevert(this.token.transferFrom(approver, to, amount, { from: spender }));
+            });
+        });
+
+        describe('when the recipient is the Xchng contract address', function () {
+            const amount = 100;
+
+            beforeEach(async function () {
+                await this.token.approve(spender, amount, { from: approver });
+            });
+
+            it('reverts', async function () {
+                await assertRevert(this.token.transferFrom(approver, this.token.address, amount, { from: spender }));
             });
         });
     });


### PR DESCRIPTION
### Description of the Change

Updated Transfer event in transferFrom function to use the correct from address. 
Updated the XchngToken unit tests to include transferFrom and a few missing cases (Constructor with ZERO address and transfer to Xchng contract).
